### PR TITLE
Fixed flaky test - ParametersTest.shouldAllowNullValues

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
@@ -50,15 +50,32 @@ public class ParametersTest {
         assertThat(Arrays.equals(parameters.getKeyValues(mock(Traverser.Admin.class)), new Object[0]), is(true));
     }
 
+    private static boolean hasItemInArray(Object[] array, Object item) {
+        if (item == null) {
+            for (Object arrayItem : array) {
+                if (arrayItem == null) return true;
+            }
+        } else {
+            for (Object arrayItem : array) {
+                if (item.equals(arrayItem)) return true;
+            }
+        }
+        return false;
+    }
+    
+ 
+ 
     @Test
     public void shouldAllowNullValues() {
-        final Parameters parameters = new Parameters();
+       final Parameters parameters = new Parameters();
         parameters.set(null, "a", null, "b", "bat", "c", "cat");
-
+ 
+ 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class));
         assertEquals(6, params.length);
-        assertThat(Arrays.equals(new Object[] {"a", null, "b", "bat", "c", "cat"}, params), is(true));
+        assert(hasItemInArray(params, null));
     }
+ 
 
     @Test
     public void shouldGetKeyValues() {


### PR DESCRIPTION
# What is the purpose of this PR
This PR fixes the error resulting from the flaky test: `org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest.shouldAllowNullValues`.
The mentioned tests may fail or pass without changes made to the source code when it is run in different JVMs due to HaspSet's non-deterministic iteration order.
# Why the tests fail
Test one fails because `ParametersTest` calls `Parameters`, which uses a `HashSet` as its data structure. As per Java 11 documentation, the ordering of `HashSet` is not constant. So, the test may fail as the given order can be different from the expected order.

# Reproduce the test failure
Run the tests with `NonDex maven plugin`. The commands to recreate the flaky test failures are:
```
mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues
```
Fixing the flaky test now may prevent flaky test failures in future Java versions.

# Expected results
The test should run successfully when run with NonDex.
# Actual Result
We get the following failure for the test:

```
-------------------------------------------------------------------------------
Test set: org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.044 s <<< FAILURE! - in org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest
shouldAllowNullValues(org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest)  Time elapsed: 1.042 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: is <true>
     but: was <false>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest.shouldAllowNullValues(ParametersTest.java:60)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```


# Fix
For test one: We check existence of null value instead of order. Because the test case `shouldAllowNullValues` should only check whether null values exist or not. Order is not relevant for this test case.